### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,7 @@ Depends: dictionaries-common (>= 0.10) | openoffice.org-updatedicts, ${misc:Depe
 Recommends: libreoffice-writer | openoffice.org-writer
 Replaces: openoffice.org-hyphenation-ru
 Provides: hyphen-hyphenation-patterns, hyphen-hyphenation-patterns-ru, openoffice.org-hyphenation-ru
+Multi-Arch: foreign
 Description: Russian hyphenation patterns for LibreOffice/OpenOffice.org
  Hyphenation is the process of inserting hyphens in between the syllables of
  a word so that when the text is justified, maximum space is utilized.


### PR DESCRIPTION


Apply hints suggested by the multi-arch hinter.



These changes were suggested on https://wiki.debian.org/MultiArch/Hints.

Note that in some cases, these multi-arch hints may trigger lintian warnings
until the dependencies of the package support multi-arch. This is expected,
see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.



This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/hyphen-ru/f873a986-93bb-481f-bcfe-f970bb7d8982.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f873a986-93bb-481f-bcfe-f970bb7d8982/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f873a986-93bb-481f-bcfe-f970bb7d8982/diffoscope)).
